### PR TITLE
fix: when writing the log, store model instead of name

### DIFF
--- a/django_action_logger/models.py
+++ b/django_action_logger/models.py
@@ -12,7 +12,7 @@ class DjangoActionLogEntryManager(models.Manager):
         if obj:
             content_type = ContentType.objects.get_for_model(obj)
             entry.content_type = content_type
-            natural_key = f"{content_type.app_label}.{content_type.name}"
+            natural_key = f"{content_type.app_label}.{content_type.model}"
             metadata["natural_key"] = natural_key
             message += f" {natural_key}: {obj}"
             metadata["pk"] = obj.pk


### PR DESCRIPTION
Then `name` in the contenttype frameork is the human readable name - but
it makes more sense to use the `model` to create the natural key.
